### PR TITLE
Evaluate the repository with terraform0.13upgrade binary

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
In our vision to upgrade Terraform to 0.13, we will need to run this binary over any Terraform files in our repository.